### PR TITLE
Fix typo in compileScenario comment

### DIFF
--- a/src/compileScenario.js
+++ b/src/compileScenario.js
@@ -78,7 +78,7 @@ export const compileScenario = (scenario, { blocks = {}, callbacks = {}, initial
     }
   }
 
-  // validate exising label used by goto and ifJump
+  // validate existing label used by goto and ifJump
   const seenLabels = new Set(Object.keys(labels));
   steps.filter(step => step.type === "goto" || step.type === "ifJump").forEach(step => {
     if(step.type === "goto" && !seenLabels.has(step.label)) validationErrors.push(`Missing label : ${step.label}`);


### PR DESCRIPTION
## Summary
- correct comment about validating existing labels

## Testing
- `npm test` *(fails: Cannot find module 'jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_6842946ea3f88320af0057edf7cfcb14