### PR TITLE
Improve ifElse validation

### DIFF
--- a/src/compileScenario.js
+++ b/src/compileScenario.js
@@ -95,6 +95,8 @@ export const compileScenario = (scenario, { blocks = {}, callbacks = {}, initial
     } else if (step.type === "ifElse") {
       if (stack.length === 0 || stack[stack.length - 1].type !== "ifThen") {
         validationErrors.push(`"ifElse" at step ${i} has no matching "ifThen"`);
+      } else if (stack[stack.length - 1].hasElse) {
+        validationErrors.push(`"ifElse" at step ${i} already defined for this block`);
       } else {
         stack[stack.length - 1].hasElse = true;
       }


### PR DESCRIPTION
## Summary
- detect multiple `ifElse` branches in the same `ifThen` block

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68429841f9048320a74ee4a8c10e526f